### PR TITLE
Fix/correccion borrado logico misiones

### DIFF
--- a/controllers/Missions/Missions.controller.js
+++ b/controllers/Missions/Missions.controller.js
@@ -69,11 +69,12 @@ exports.editMission = async (req, res) => {
 exports.deleteMission = async (req, res) => {
     try {
         const id = req.params.id;
-        const result = await Mission.deleteMissionById(id);
+        // Borrado lógico: actualizar available a 0
+        const result = await Mission.update(id, { available: 0 });
         if (result[0].affectedRows === 0) {
             return res.status(404).json({ success: false, message: 'Mission not found' });
         }
-        res.json({ success: true, message: 'Mission deleted successfully' });
+        res.json({ success: true, message: 'Mission deleted (logical) successfully' });
     } catch (err) {
         res.status(500).json({ success: false, message: 'Error deleting mission' });
     }

--- a/controllers/Missions/Missions.controller.js
+++ b/controllers/Missions/Missions.controller.js
@@ -69,7 +69,7 @@ exports.editMission = async (req, res) => {
 exports.deleteMission = async (req, res) => {
     try {
         const id = req.params.id;
-        // Borrado lógico: actualizar available a 0
+        // Borrado logico para actualizar a 0
         const result = await Mission.update(id, { available: 0 });
         if (result[0].affectedRows === 0) {
             return res.status(404).json({ success: false, message: 'Mission not found' });

--- a/models/Missions/Missions.model.js
+++ b/models/Missions/Missions.model.js
@@ -52,7 +52,6 @@ module.exports = class Mission{
      * @returns {Promise}
      */
     static update(id, data) {
-        // Si solo se quiere actualizar 'available' (borrado lógico)
         if (Object.keys(data).length === 1 && data.available !== undefined) {
             return db.execute(
                 'UPDATE mission SET available=? WHERE IDMission=?',

--- a/models/Missions/Missions.model.js
+++ b/models/Missions/Missions.model.js
@@ -32,7 +32,8 @@ module.exports = class Mission{
      * @returns {Promise}
      */
     static fetchAll() {
-        return db.execute('SELECT * FROM mission');
+    // Solo misiones activas (borrado lógico)
+    return db.execute('SELECT * FROM mission WHERE available=1');
     }
 
     /**
@@ -51,6 +52,14 @@ module.exports = class Mission{
      * @returns {Promise}
      */
     static update(id, data) {
+        // Si solo se quiere actualizar 'available' (borrado lógico)
+        if (Object.keys(data).length === 1 && data.available !== undefined) {
+            return db.execute(
+                'UPDATE mission SET available=? WHERE IDMission=?',
+                [data.available, id]
+            );
+        }
+        // Actualización normal de misión
         return db.execute(
             'UPDATE mission SET responseVerification=?, category=?, description=?, available=?, experience=? WHERE IDMission=?',
             [

--- a/public/js/missions/missions.js
+++ b/public/js/missions/missions.js
@@ -112,10 +112,12 @@ form.addEventListener("submit", function(e) {
 document.getElementById('delete-btn').addEventListener('click', function() {
     if (confirm('¿Seguro que quieres eliminar esta misión?')) {
         const missionId = document.getElementById('id').value;
+        const csrfToken = document.querySelector('input[name="_csrf"]').value;
         fetch(`/missions/${missionId}`, {
             method: 'DELETE',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'CSRF-Token': csrfToken
             }
         })
         .then(res => res.json())


### PR DESCRIPTION
Descripción del PR

Se implementó el borrado lógico para misiones y se corrigió el envío del token CSRF en las peticiones DELETE. Ahora las misiones eliminadas no se borran físicamente, solo se marcan como inactivas y no aparecen en la vista. Además, se asegura la protección contra ataques CSRF, ya no se eliminan por ID.

Archivos modificados
controllers/Missions/Missions.controller.js
models/Missions/Missions.model.js
public/js/missions/missions.js

Cambios principales
 Se implementó el borrado lógico (actualización del campo `available` a 0).
 Se modificó la consulta para mostrar solo misiones activas.
Se corrigió el frontend para enviar el token CSRF en la petición DELETE.
Se mantiene la integridad y seguridad de la aplicación.

Checklist (Definition of Done)
- Borrado lógico implementado.
- CSRF funcionando en DELETE.
-  Solo misiones activas visibles.
-  Pruebas manuales realizadas.
-  Archivos y carpetas organizados dentro de la estructura del proyecto.
